### PR TITLE
update areas, achievs, MessageResolverTBC link to Ascension DB (?)

### DIFF
--- a/src/main/resources/achievements.csv
+++ b/src/main/resources/achievements.csv
@@ -19361,7 +19361,7 @@
 87211,Path to Ascension: Legendary Mystic Enchant Collecting
 87212,Path to Ascension: Dungeon Diving
 87213,Path to Ascension: Heroic Dungeons
-87214,Path to Ascension: Flex Raiding
+87214,Path to Ascension: Normal Raiding
 87215,Path to Ascension: Mythic Dungeons
 87216,Path to Ascension: Mythic+ Dungeons
 87217,Path to Ascension: Heroic Raiding
@@ -19438,71 +19438,71 @@
 87289,Path to Ascension Wildcard:
 87290,Path to Ascension Wildcard:
 87291,Path to Ascension Wildcard:
-87292,Path to Ascension:
-87293,Path to Ascension: Normal: Hakkar
-87294,Path to Ascension: Normal: Ragnaros
-87295,Path to Ascension: Normal: Onyxia (Vanilla)
-87296,Path to Ascension: Normal: Nefarian
-87297,Path to Ascension: Normal: Ossirian the Unscarred
-87298,Path to Ascension: Normal: C'thun
-87299,Path to Ascension: Normal: Kel'thuzad
-87300,Path to Ascension: Heroic: Hakkar
-87301,Path to Ascension: Heroic: Ragnaros
-87302,Path to Ascension: Heroic: Onyxia (Vanilla)
-87303,Path to Ascension: Heroic: Nefarian
-87304,Path to Ascension: Heroic: Ossirian the Unscarred
-87305,Path to Ascension: Heroic: C'thun
-87306,Path to Ascension: Heroic: Kel'thuzad
-87307,Path to Ascension: Mythic: Hakkar
-87308,Path to Ascension: Mythic: Ragnaros
-87309,Path to Ascension: Mythic: Onyxia (Vanilla)
-87310,Path to Ascension: Mythic: Nefarian
-87311,Path to Ascension: Mythic: Ossirian the Unscarred
-87312,Path to Ascension: Mythic: C'thun
-87313,Path to Ascension: Mythic: Kel'thuzad
-87314,Path to Ascension: Ascended: Hakkar
-87315,Path to Ascension: Ascended: Ragnaros
-87316,Path to Ascension: Ascended: Onyxia (Vanilla)
-87317,Path to Ascension: Ascended: Nefarian
-87318,Path to Ascension: Ascended: Ossirian the Unscarred
-87319,Path to Ascension: Ascended: C'thun
-87320,Path to Ascension: Ascended: Kel'thuzad
-87321,Path to Ascension: Normal: Prince Malchezaar
-87322,Path to Ascension: Normal: Gruul the Dragonkiller
-87323,Path to Ascension: Normal: Magtheridon
-87324,Path to Ascension: Normal: Lady Vashj
-87325,Path to Ascension: Normal: Kael'thas Sunstrider
-87326,Path to Ascension: Normal: Zul'Jin
-87327,Path to Ascension: Normal: Archimonde
-87328,Path to Ascension: Normal: Illidan Stormrage
-87329,Path to Ascension: Normal: Kil'Jaeden
-87330,Path to Ascension: Heroic: Prince Malchezaar
-87331,Path to Ascension: Heroic: Gruul the Dragonkiller
-87332,Path to Ascension: Heroic: Magtheridon
-87333,Path to Ascension: Heroic: Lady Vashj
-87334,Path to Ascension: Heroic: Kael'thas Sunstrider
-87335,Path to Ascension: Heroic: Zul'Jin
-87336,Path to Ascension: Heroic: Archimonde
-87337,Path to Ascension: Heroic: Illidan Stormrage
-87338,Path to Ascension: Heroic: Kil'Jaeden
-87339,Path to Ascension: Mythic: Prince Malchezaar
-87340,Path to Ascension: Mythic: Gruul the Dragonkiller
-87341,Path to Ascension: Mythic: Magtheridon
-87342,Path to Ascension: Mythic: Lady Vashj
-87343,Path to Ascension: Mythic: Kael'thas Sunstrider
-87344,Path to Ascension: Mythic: Zul'Jin
-87345,Path to Ascension: Mythic: Archimonde
-87346,Path to Ascension: Mythic: Illidan Stormrage
-87347,Path to Ascension: Mythic: Kil'Jaeden
-87348,Path to Ascension: Ascended: Prince Malchezaar
-87349,Path to Ascension: Ascended: Gruul the Dragonkiller
-87350,Path to Ascension: Ascended: Magtheridon
-87351,Path to Ascension: Ascended: Lady Vashj
-87352,Path to Ascension: Ascended: Kael'thas Sunstrider
-87353,Path to Ascension: Ascended: Zul'Jin
-87354,Path to Ascension: Ascended: Archimonde
-87355,Path to Ascension: Ascended: Illidan Stormrage
-87356,Path to Ascension: Ascended: Kil'Jaeden
+87292,Conqueror of Zul'Gurub
+87293,Path to Ascension: Normal Zul'Gurub
+87294,Path to Ascension: Normal Molten Core
+87295,Path to Ascension: Normal Onyxia's Lair
+87296,Path to Ascension: Normal Blackwing Lair
+87297,Path to Ascension: Normal Ruins of Ahn'Qiraj
+87298,Path to Ascension: Normal Temple of Ahn'Qiraj
+87299,Path to Ascension: Normal Naxxramas
+87300,Path to Ascension: Heroic Zul'Gurub
+87301,Path to Ascension: Heroic Molten Core
+87302,Path to Ascension: Heroic Onyxia's Lair
+87303,Path to Ascension: Heroic Blackwing Lair
+87304,Path to Ascension: Heroic Ruins of Ahn'Qiraj
+87305,Path to Ascension: Heroic Temple of Ahn'Qiraj
+87306,Path to Ascension: Heroic Naxxramas
+87307,Path to Ascension: Mythic Zul'Gurub
+87308,Path to Ascension: Mythicl Molten Core
+87309,Path to Ascension: Mythic Onyxia's Lair
+87310,Path to Ascension: Mythic Blackwing Lair
+87311,Path to Ascension: Mythic Ruins of Ahn'Qiraj
+87312,Path to Ascension: Mythic Temple of Ahn'Qiraj
+87313,Path to Ascension: Mythic Naxxramas
+87314,Path to Ascension: Ascended Zul'Gurub
+87315,Path to Ascension: Ascended Molten Core
+87316,Path to Ascension: Ascended Onyxia's Lair
+87317,Path to Ascension: Ascended Blackwing Lair
+87318,Path to Ascension: Ascended Ruins of Ahn'Qiraj
+87319,Path to Ascension: Ascended Temple of Ahn'Qiraj
+87320,Path to Ascension: Ascended Naxxramas
+87321,Path to Ascension: Normal Karazhan
+87322,Path to Ascension: Normal Gruul's Lair
+87323,Path to Ascension: Normal Magtheridon's Lair
+87324,Path to Ascension: Normal Serpentshrine Cavern
+87325,Path to Ascension: Normal Tempest Keep
+87326,Path to Ascension: Normal Zul'Aman
+87327,Path to Ascension: Normal Battle for Mount Hyjal
+87328,Path to Ascension: Normal Black Temple
+87329,Path to Ascension: Normal Sunwell Plateau
+87330,Path to Ascension: Heroic Karazhan
+87331,Path to Ascension: Heroic Gruul's Lair
+87332,Path to Ascension: Heroic Magtheridon's Lair
+87333,Path to Ascension: Heroic Serpentshrine Cavern
+87334,Path to Ascension: Heroic Tempest Keep
+87335,Path to Ascension: Heroic Zul'Aman
+87336,Path to Ascension: Heroic Battle for Mount Hyjal
+87337,Path to Ascension: Heroic Black Temple
+87338,Path to Ascension: Heroic Sunwell Plateau
+87339,Path to Ascension: Mythic Karazhan
+87340,Path to Ascension: Mythic Gruul's Lair
+87341,Path to Ascension: Mythic Magtheridon's Lair
+87342,Path to Ascension: Mythic Serpentshrine Cavern
+87343,Path to Ascension: Mythic Tempest Keep
+87344,Path to Ascension: Mythic Zul'Aman
+87345,Path to Ascension: Mythic Battle for Mount Hyjal
+87346,Path to Ascension: Mythic Black Temple
+87347,Path to Ascension: Mythic Sunwell Plateau
+87348,Path to Ascension: Ascended Karazhan
+87349,Path to Ascension: Ascended Gruul's Lair
+87350,Path to Ascension: Ascended Magtheridon's Lair
+87351,Path to Ascension: Ascended Serpentshrine Cavern
+87352,Path to Ascension: Ascended Tempest Keep
+87353,Path to Ascension: Ascended Zul'Aman
+87354,Path to Ascension: Ascended Battle for Mount Hyjal
+87355,Path to Ascension: Ascended Black Temple
+87356,Path to Ascension: Ascended Sunwell Plateau
 87357,Path to Ascension: Gear Up for Zul'Gurub
 87358,Path to Ascension: Gear Up for Mythic Dungeons
 87359,Path to Ascension: Gear Up for Molten Core
@@ -19527,6 +19527,10 @@
 87378,Path to Ascension: Purchase Honor Gear
 87379,Path to Ascension: Purchase Honor Gear
 87380,Path to Ascension: PvP Progression Vendor
+87381,Path to Ascension: Reach Level 20 in Wildcard!
+87382,Path to Ascension: Reach Level 60 in Wildcard!
+87383,Path to Ascension: Reach Level 70 in Wildcard!
+87384,Path to Ascension: Wildcard Prestige
 108026,Ascended: High Priest Venoxis
 108027,Ascended: High Priestess Mar'li
 108028,Ascended: Bloodlord Mandokir

--- a/src/main/resources/pre_cata_areas.csv
+++ b/src/main/resources/pre_cata_areas.csv
@@ -2309,7 +2309,7 @@
 4987,The Ruby Sanctum
 4990,The Twisting Nether
 4999,Twisting Nether
-5000,FFA BG (Test)
+5000,Battle Royal
 5001,Demon's Tears
 5002,Sty'La
 5003,Open World
@@ -2355,7 +2355,7 @@
 6032,Silver Covenant Pavilion
 6033,Sunreaver Pavilion
 6051,The Temple of Kotmogu
-6060,Temple of Kotmogu
+6060,The Temple of Kotmogu
 6061,The Temple of Kotmogu
 6136,The Temple of Kotmogu
 6137,Guardian's Hall
@@ -2398,7 +2398,7 @@
 10013,Mish Faramos
 10014,Dungeon Dev Map
 10015,Raid Dev Map
-10016,Mini Games
+10016,Azzar Faire Mini Games
 10017,Housing Human
 10018,Newnerub
 10019,Azzar Island
@@ -2442,6 +2442,55 @@
 10057,Black Rook Hold
 10058,Black Rook Hold Arena
 10059,The Robodrome
+10060,Pools of the Eidola
+10061,Nightmare's Hand
+10062,Path of Shame
+10065,Stormwind Sewers
+10066,OutdoorDevMap
+10067,MinigamesDevMap
+10068,AzzarEvent
+10069,Bullet Romper
+10070,Eye of the Shadow
+10071,Duck Hunt
+10072,RainBow Race
+10073,Vertical Ascend
+10074,Kul Tiran Ascent
+10075,Mechagnomic Ascent
+10076,Titanic Ascent
+10077,Volcanic Ascent
+10078,Azzar Archipelago
+10079,Azure Bloom
+10080,Tower of the Anointed
+10081,Glorious Azzar Faire
+10082,Forest Cabins
+10083,Fairground Dump
+10084,Sunken Ruins
+10085,Cursed Vrykul Ruins
+10086,Infested Ruins
+10087,Ancient Vrykul Cathedral
+10088,Ala’Taclar
+10089,Great Temple of the Sleeper
+10090,City of Azdalar
+10091,Last Burial Ground
+10092,Crypt of the Skeptic
+10093,Beach Bar
+10094,Showmen's Alley
+10095,Snail Race Alley
+10096,Azzar’fon Mountain
+10097,RobinDevMap
+10098,Emerald Ascent
+10099,Naga Ascent
+10100,Test FFa
+10101,Dark Iron Ascent
+10102,Zandalari Ascent
+10103,Legion Ascent
+10104,Frozen Tears Sanctum
+10105,Frozen Tears Sanctum - First floor
+10106,Frozen Tears Sanctum - Second floor
+10107,Frozen Tears Sanctum - Third floor
+10108,Tinkertech Showdown
+10109,Baradin Hold
+10110,Dawnrise Island
 11211,Ascension
 11220,Stormwind City
 11221,Orgrimmar
@@ -2484,3 +2533,4 @@
 11435,Iskirr Village
 11437,The Forgotten Isle
 11439,Eonar's Cradle
+11440,The Karazhan Crypts

--- a/src/main/scala/wowchat/discord/MessageResolver.scala
+++ b/src/main/scala/wowchat/discord/MessageResolver.scala
@@ -186,7 +186,7 @@ class MessageResolverTBC(jda: JDA) extends MessageResolver(jda) {
     "quest" -> "\\|.+?\\|Hquest:(\\d+):.+?\\|h\\[(.+?)\\]\\|h\\|r\\s?".r
   )
 
-  override protected val linkSite = "http://tbc-twinhead.twinstar.cz"
+  override protected val linkSite = "https://db.ascension.gg/"
 }
 
 class MessageResolverWotLK(jda: JDA) extends MessageResolverTBC(jda) {


### PR DESCRIPTION
this is what I was referring to in Discord

would this be necessary if/when Elune goes into TBC?
i am yet to test this change, and haven't noticed anything from A52 link to the previous site I replaced

i have also updated the areas and achievements for season 9 chapter 3 "mega update"